### PR TITLE
make CLI_OPTS runtime overridable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG CLI_OPTS=-Xmx900m
 
 RUN mkdir /app
 RUN mkdir /data
-RUN echo "cd /data && CLI_OPTS='${CLI_OPTS}' /app/hapi-fhir-cli run-server --allow-external-refs --disable-referential-integrity -f ${FHIR} -p \${PORT:-8080}" > /app/cmd
+RUN echo "cd /data && CLI_OPTS='\${CLI_OPTS_OVERRIDE-\$CLI_OPTS}' /app/hapi-fhir-cli run-server --allow-external-refs --disable-referential-integrity -f ${FHIR} -p \${PORT:-8080}" > /app/cmd
 
 # COPY ./hapi-fhir-3.2.0-cli/* /app/
 ADD https://github.com/jamesagnew/hapi-fhir/releases/download/v3.2.0/hapi-fhir-3.2.0-cli.tar.bz2 /tmp/hapi-cli/


### PR DESCRIPTION
Hi,

When attempting to increase the memory on a k8s deployed sandbox we noticed that there was no quick & easy way to increase the memory without a workaround or rebuilding the dockerfile. Having the ARG as a build time option didn't really help.

We've kept the build backwards compatible while providing a ENV_VAR that can be overridden to change the params at runtime.

Kind regards,
Kris